### PR TITLE
Change loglevel from Info to Debug for retrieving the cache state.

### DIFF
--- a/src/platformAccessory.ts
+++ b/src/platformAccessory.ts
@@ -109,7 +109,7 @@ export class AppleTVAccessory {
   }
 
   getCachedPowerState(): boolean {
-    this.platform.log.info('Retrieved cachedPowerState: ' + this.cachedPowerState);
+    this.platform.log.debug('Retrieved cachedPowerState: ' + this.cachedPowerState);
     return this.cachedPowerState;
   }
 


### PR DESCRIPTION
Hi,

I just installed the newest version of the plugin and noticed that the log is completly full with messages of the new caching functionality. Therefore I would suggest to change the loglevel from info to debug when retreiving the cache state.

Greetings
Maxi